### PR TITLE
feat: prefer standard methods over legacy methods

### DIFF
--- a/_posts/2017/2017-12-17-touch-file-nodejs.md
+++ b/_posts/2017/2017-12-17-touch-file-nodejs.md
@@ -2,8 +2,8 @@
 layout: post
 title: How to touch a file in Node.js
 date: 2017-12-17 16:44:13
-updated: 2019-07-20 23:08:43
-excerpt: How to touch a file in Node.js using synchronous and asynchronous `fs` methods.
+updated: 2022-09-08 10:35:55
+excerpt: How to touch a file in Node.js using the standard promise (async) and legacy synchronous `fs` methods.
 categories: touch file nodejs javascript
 ---
 
@@ -12,52 +12,51 @@ categories: touch file nodejs javascript
 To create an empty file in [Node.js](https://nodejs.org/):
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs/promises');
 const filename = 'file.txt';
-fs.closeSync(fs.openSync(filename, 'w'));
+let fh = await fs.open(filename, 'w');
+await fh.close();
 ```
 
-Here, a (blank) file is written with [fs.openSync](https://nodejs.org/api/fs.html#fs_fs_opensync_path_flags_mode) and then closed with [fs.closeSync](https://nodejs.org/api/fs.html#fs_fs_closesync_fd).
+Here, a (blank) file is written with [fs.open](https://nodejs.org/api/fs.html#fspromisesopenpath-flags-mode) and then closed with [fh.close](https://nodejs.org/api/fs.html#filehandleclose).
 
 ## touch file
 
 To `touch` a file, however, requires a bit more work (_credit [boutell](https://disq.us/p/21rurrt)_):
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs/promises');
+const filename = 'file.txt';
+const time = new Date();
+
+await fs.utimes(filename, time, time).catch(async function (err) {
+    if ('ENOENT' !== err.code) {
+        throw err;
+    }
+    let fh = await fs.open(filename, 'w');
+    await fh.close();
+});
+```
+
+[fs.utimes](https://nodejs.org/api/fs.html#fspromisesutimespath-atime-mtime) is used here to prevent existing file contents from being overwritten.
+
+It also updates the last modification timestamp of the file, which is consistent with what POSIX `touch` does.
+
+### Blocking
+
+To do this synchronously, we can use the legacy blocking methods [fs.closeSync](https://nodejs.org/api/fs.html#fsclosesyncfd), [fs.openSync](https://nodejs.org/api/fs.html#fsopensyncpath-flags-mode), [fs.utimesSync](https://nodejs.org/api/fs.html#fsutimessyncpath-atime-mtime):
+
+```js
+const fs = require('node:fs');
 const filename = 'file.txt';
 const time = new Date();
 
 try {
-  fs.utimesSync(filename, time, time);
-} catch (err) {
-  fs.closeSync(fs.openSync(filename, 'w'));
+    fs.utimesSync(filename, time, time);
+} catch (e) {
+    let fd = fs.openSync(filename, 'w');
+    fs.closeSync(fd);
 }
-```
-
-[fs.utimesSync](https://nodejs.org/api/fs.html#fs_fs_utimessync_path_atime_mtime) is used here to prevent existing file contents from being overwritten.
-
-It also updates the last modification timestamp of the file, which is consistent with what POSIX `touch` does.
-
-### Callback
-
-To do this asynchronously, we can use the non-blocking methods [fs.close](https://nodejs.org/api/fs.html#fs_fs_close_fd_callback), [fs.open](https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback), [fs.utimes](https://nodejs.org/api/fs.html#fs_fs_utimes_path_atime_mtime_callback):
-
-```js
-const fs = require('fs');
-const filename = 'file.txt';
-const time = new Date();
-
-fs.utimes(filename, time, time, err => {
-  if (err) {
-    fs.open(filename, 'w', (err, fd) => {
-      if (err) throw err;
-      fs.close(fd, err => {
-        if (err) throw err;
-      });
-    });
-  }
-});
 ```
 
 ## Examples


### PR DESCRIPTION
I came across this while searching for a quick copy-and-paste snippet to touch a file and it was one of the first results.

However, this article currently describes how this would have been done back in 2010. In the past 10 years the Node API has improved greatly.

I've updated the article with clear, idiomatic examples of uses the current API and distinguishing that from the legacy API.